### PR TITLE
Updating Cosmos DB for Python example with additional features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,143 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+##Github Python Ignore Standard (https://github.com/github/gitignore/blob/master/Python.gitignore)
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Azure Cosmos DB is Microsoft’s globally distributed multi-model database servi
         * Create with [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest) with this command: `az cosmosdb create --name <account-name> --resource-group <resource-group-name>`. Note that the default API is Core (SQL) when creating a Cosmos DB account with the CLI.
     * [Visual Studio Code](https://code.visualstudio.com/)
     * [Python extention for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python#overview)
-    * [Python 3.6+](https://www.python.org/downloads/) with \<install location\>\Python36 and \<install location>\Python36\Scripts added to your PATH. 
+    * [Python 3.6+](https://www.python.org/downloads/) with \<install location\>\Python36 and \<install location>\Python36\Scripts added to your PATH. You can also acquire Python 3.8 from the Microsoft Store.
     * [Azure Cosmos DB Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/cosmos/azure-cosmos) - Install with this command: `pip install azure-cosmos`
 
 * Clone this repository using: 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ Azure Cosmos DB is Microsoft’s globally distributed multi-model database servi
     Query returned 2 items. Operation consumed 3.09 request units
     ```
 
-* If you see the following error, then ensure you have installed the Azure Cosmos DB SDK properly with the `--pre` flag.  See prerequisites section above for details.
-
-    ```
-    Traceback (most recent call last):
-    File "cosmos_get_started.py", line 1, in <module>
-        from azure.cosmos import exceptions, CosmosClient, PartitionKey
-    ImportError: cannot import name 'exceptions' from 'azure.cosmos' (...\lib\site-packages\azure\cosmos\__init__.py)
-    ```
-
 * You can view the items that this sample created by navigating to the [Azure Cosmos DB Data Explorer](https://cosmos.azure.com/) and selecting the AzureSampleFamilyDatabase:
 
     !['Azure Cosmos DB Data Explorer](assets/dataexplorer.png)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Azure Cosmos DB is Microsoft’s globally distributed multi-model database servi
     * [Visual Studio Code](https://code.visualstudio.com/)
     * [Python extention for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python#overview)
     * [Python 3.6+](https://www.python.org/downloads/) with \<install location\>\Python36 and \<install location>\Python36\Scripts added to your PATH. 
-    * [Azure Cosmos DB Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/cosmos/azure-cosmos) - Install with this command: `pip install --pre azure-cosmos`
+    * [Azure Cosmos DB Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/cosmos/azure-cosmos) - Install with this command: `pip install azure-cosmos`
 
 * Clone this repository using: 
      `git clone https://github.com/Azure-Samples/azure-cosmos-db-python-getting-started.git`

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -5,47 +5,62 @@ import family
 endpoint = "endpoint"
 key = 'primary_key'
 
-# <create_cosmos_client>
+#region Create Cosmos Client
 client = CosmosClient(endpoint, key)
-# </create_cosmos_client>
+#endregion
 
 # Create a database
-# <create_database_if_not_exists>
+#region Create a Database
 database_name = 'AzureSampleFamilyDatabase'
 database = client.create_database_if_not_exists(id=database_name)
-# </create_database_if_not_exists>
+#endregion
 
 # Create a container
 # Using a good partition key improves the performance of database operations.
-# <create_container_if_not_exists>
+# See detailed documentation on partition keys here:
+# https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview
+
+#region Create Container if doesn't exist
 container_name = 'FamilyContainer'
 container = database.create_container_if_not_exists(
     id=container_name, 
     partition_key=PartitionKey(path="/lastName"),
     offer_throughput=400
 )
-# </create_container_if_not_exists>
+#endregion
 
+# Reconnecting to Azure Cosmos DB after creating database and container
+# This isn't normal but included to give example of how to connect to existing database and container
+# without creating a new database and container
+#region Reconnection
+client = CosmosClient(endpoint, key)
+database = client.get_database_client(database=database_name)
+container = database.get_container_client(container=container_name)
+#endregion
 
 # Add items to the container
-family_items_to_create = [family.get_andersen_family_item(), family.get_johnson_family_item(), family.get_smith_family_item(), family.get_wakefield_family_item()]
+family_items_to_create = [family.get_andersen_family_item(), 
+    family.get_johnson_family_item(), 
+    family.get_smith_family_item(), 
+    family.get_wakefield_family_item()]
 
- # <create_item>
+#region Create Items
 for family_item in family_items_to_create:
     container.create_item(body=family_item)
-# </create_item>
+#endregion
 
 # Read items (key value lookups by partition key and id, aka point reads)
-# <read_item>
+#region Read Item
 for family in family_items_to_create:
     item_response = container.read_item(item=family['id'], partition_key=family['lastName'])
     request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
     print('Read item with id {0}. Operation consumed {1} request units'.format(item_response['id'], (request_charge)))
-# </read_item>
+#endregion
 
 # Query these items using the SQL query syntax. 
-# Specifying the partition key value in the query allows Cosmos DB to retrieve data only from the relevant partitions, which improves performance
-# <query_items>
+# Specifying the partition key value in the query allows Cosmos DB 
+# to retrieve data only from the relevant partitions, which improves performance
+#region Query items by Partition key
 query = "SELECT * FROM c WHERE c.lastName IN ('Wakefield', 'Andersen')"
 
 items = list(container.query_items(
@@ -56,4 +71,4 @@ items = list(container.query_items(
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
 
 print('Query returned {0} items. Operation consumed {1} request units'.format(len(items), request_charge))
-# </query_items>
+#endregion

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -101,7 +101,7 @@ result = container.upsert_item(item) #Cosmos will return updated item
 
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
 
-print(f'Update completed and consumed {request_charge} requests units')
+print(f'Update completed and consumed {request_charge} request units')
 #endregion
 
 # Delete Item
@@ -122,7 +122,7 @@ container.delete_item(
 
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
 
-print(f'Delete completed and consumed {request_charge} requests units')
+print(f'Delete completed and consumed {request_charge} request units')
 
 # Prove that delete was completed
 query = "SELECT * FROM f WHERE f.lastname = 'Johnson' AND f.registered = false"

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -110,7 +110,7 @@ print(f'Update completed and consumed {request_charge} request units')
 # Deleting item requires passing in full item and partition key which in this example
 # is lastname (see line 27)
 #region Delete Item and confirm
-query = "SELECT * FROM f WHERE f.lastname = 'Johnson' AND f.registered = false"
+query = "SELECT * FROM f WHERE f.lastName = 'Johnson' AND f.registered = false"
 
 items = list(container.query_items(
     query = query,

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -119,7 +119,7 @@ items = list(container.query_items(
 
 container.delete_item(
     item = items[0], #First item in list
-    partition_key = items[0]['lastname'] #Partition key
+    partition_key = items[0]['lastName'] #Partition key
 )
 
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -116,6 +116,9 @@ items = list(container.query_items(
     query = query,
     enable_cross_partition_query = True
 ))
+request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
+
+print('Query returned {0} items. Operation consumed {1} request units'.format(len(items), request_charge))
 
 container.delete_item(
     item = items[0], #First item in list
@@ -127,7 +130,7 @@ request_charge = container.client_connection.last_response_headers['x-ms-request
 print(f'Delete completed and consumed {request_charge} request units')
 
 # Prove that delete was completed
-query = "SELECT * FROM f WHERE f.lastname = 'Johnson' AND f.registered = false"
+query = "SELECT * FROM f WHERE f.lastName = 'Johnson' AND f.registered = false"
 
 items = list(container.query_items(
     query = query,
@@ -137,6 +140,6 @@ items = list(container.query_items(
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
 
 if not items: #Empty list
-    print(f'Confirmed Item deleted and query consumed {request_charge} request units')
+    print(f'Confirmed item was deleted and query consumed {request_charge} request units')
 
 #endregion

--- a/cosmos_get_started.py
+++ b/cosmos_get_started.py
@@ -96,8 +96,10 @@ print('Query returned {0} items. Operation consumed {1} request units'.format(le
 # Update family returned from last query
 #region Update record
 item = items[0] #query items come back as list of dictionary so putting into seperate dictionary for ease
-item['children'] = [{'firstname': 'Liam', 'grade': 1}, {'firstname':'Emma','grade': 5, 'biketoschool': True}]
-result = container.upsert_item(item) #Cosmos will return updated item
+item['children'] = [{'firstname': 'Liam', 'grade': 1}, 
+    {'firstname':'Emma','grade': 5, 'biketoschool': True}]
+
+result = container.upsert_item(body=item) #Cosmos will return updated item
 
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']
 
@@ -116,8 +118,8 @@ items = list(container.query_items(
 ))
 
 container.delete_item(
-    item = items[0] #First item in list
-    partition_key = items[0]['lastname']
+    item = items[0], #First item in list
+    partition_key = items[0]['lastname'] #Partition key
 )
 
 request_charge = container.client_connection.last_response_headers['x-ms-request-charge']


### PR DESCRIPTION
CosmosDB Example was missing CRUD operations along with example of connecting to existing database. Readme also contained incorrect information with Azure-cosmos SDK v4 going GA.

Overview of updates to readme:
Remove --pre for pip install since no longer required.
Remove troubleshooting information when --pre isn't passed
Add item about Python being available in Microsoft Store

Overview of updates to cosmos_get_started.py:
Added Query not using partition key
Added Update example
Added Delete Example
Linking to documentation where appropriate
Changing out to use region comment tags since support is available in PyCharm, Visual Studio Code which are two most popular Python development environments
Cleaning up various things in attempt to respect PEP 8 better, not 100% successful but believe made code cleaner and easier to understand. 
Various minor changes to match documentation

Overview of updates to .gitignore:
Added Github standard .gitignore for python, did not remove what appeared to be standard Visual Studio git ignore